### PR TITLE
PelletReasoner enabled to work with Fuseki assembler

### DIFF
--- a/jena/src/main/java/org/mindswap/pellet/jena/PelletReasoner.java
+++ b/jena/src/main/java/org/mindswap/pellet/jena/PelletReasoner.java
@@ -27,7 +27,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
-
 package org.mindswap.pellet.jena;
 
 import java.util.logging.Logger;
@@ -51,101 +50,147 @@ import com.hp.hpl.jena.vocabulary.ReasonerVocabulary;
  * @author Evren Sirin
  */
 public class PelletReasoner implements Reasoner {
-    protected static Logger log = Logger.getLogger( PelletReasoner.class.getName() );
+
+    protected final static Logger log = Logger.getLogger(PelletReasoner.class.getName());
 
     private Model reasonerCapabilities;
 
     private Capabilities graphCapabilities;
-    
+
     private Graph schema;
-    
+
     private boolean fixedSchema;
 
-    public PelletReasoner( ) {
-        this( null, PelletReasonerFactory.theInstance().getCapabilities() );
+    public PelletReasoner() {
+        this(null, PelletReasonerFactory.theInstance().getCapabilities());
     }
 
-    public PelletReasoner( Graph schema ) {
-        this( schema, PelletReasonerFactory.theInstance().getCapabilities() );
+    public PelletReasoner(Graph schema) {
+        this(schema, PelletReasonerFactory.theInstance().getCapabilities());
     }
-    
-    protected PelletReasoner( Model reasonerCapabilities ) {
-        this( null, reasonerCapabilities );
+
+    protected PelletReasoner(Model reasonerCapabilities) {
+        this(null, reasonerCapabilities);
     }
-    
-    protected PelletReasoner( Graph schema, Model reasonerCapabilities ) {
+
+    protected PelletReasoner(Graph schema, Model reasonerCapabilities) {
         this.schema = schema;
-        this.reasonerCapabilities = reasonerCapabilities;
+        this.fixedSchema = (this.schema!=null);
         
+        this.reasonerCapabilities = reasonerCapabilities;
+
         graphCapabilities = new InfFindSafeCapabilities();
-     }
-    
+    }
+
     public Graph getSchema() {
         return schema;
     }
 
     public boolean isFixedSchema() {
-		return fixedSchema;
-	}
-
-	public void setFixedSchema(boolean fixedSchema) {
-		this.fixedSchema = fixedSchema;
-	}
-
-	public Reasoner bindSchema( Graph graph ) throws ReasonerException {
-        return new PelletReasoner( graph, reasonerCapabilities );
+        return fixedSchema;
     }
 
-    public Reasoner bindSchema( Model model ) throws ReasonerException {
-        return bindSchema( model.getGraph() );
+    public void setFixedSchema(boolean fixedSchema) {
+        this.fixedSchema = fixedSchema;
     }
 
-	public Reasoner bindFixedSchema( Graph graph ) throws ReasonerException {
-		PelletReasoner reasoner = new PelletReasoner( graph, reasonerCapabilities );
-		reasoner.setFixedSchema(true);
-		return reasoner;
+    /**
+     * Returns a copy of this reasoner with graph bound as schema.
+     * This reasoner is unchanged.
+     * @param graph Schema to be bound.
+     * @return
+     * @throws ReasonerException 
+     */
+    @Override
+    public Reasoner bindSchema(Graph graph) throws ReasonerException {
+        return new PelletReasoner(graph, reasonerCapabilities);
     }
 
-	public Reasoner bindFixedSchema( Model model ) throws ReasonerException {
-		PelletReasoner reasoner = new PelletReasoner( model.getGraph(), reasonerCapabilities );
-		reasoner.setFixedSchema(true);
-		return reasoner;
+    /**
+     * Returns a copy of this reasoner with model bound as schema.
+     * This reasoner is unchanged.
+     * @param model Schema to be bound.
+     * @return
+     * @throws ReasonerException 
+     */
+    @Override
+    public Reasoner bindSchema(Model model) throws ReasonerException {
+        return bindSchema(model.getGraph());
     }
 
-    public PelletInfGraph bind( Graph graph ) throws ReasonerException {
+    /**
+     * Returns a copy of this reasoner with graph bound as schema.     
+     * This reasoner is unchanged.
+     * Deprecated as identical to bindSchema(Graph graph).
+     * @deprecated
+     * @param graph Schema to be bound.
+     * @return
+     * @throws ReasonerException 
+     */
+    public Reasoner bindFixedSchema(Graph graph) throws ReasonerException {
+        PelletReasoner reasoner = new PelletReasoner(graph, reasonerCapabilities);
+        reasoner.setFixedSchema(true);
+        return reasoner;
+    }
+
+    /**
+     * Returns a copy of this reasoner with model bound as schema.
+     * This reasoner is unchanged.
+     * Deprecated as identical to bindSchema(Model model).
+     * @deprecated
+     * @param model Schema to be bound.
+     * @return
+     * @throws ReasonerException 
+     */
+    public Reasoner bindFixedSchema(Model model) throws ReasonerException {
+        PelletReasoner reasoner = new PelletReasoner(model.getGraph(), reasonerCapabilities);
+        reasoner.setFixedSchema(true);
+        return reasoner;
+    }
+
+    @Override
+    public PelletInfGraph bind(Graph graph) throws ReasonerException {
         log.fine("In bind!");
-        return new PelletInfGraph( graph, this, new DefaultGraphLoader() );
+        return new PelletInfGraph(graph, this, new DefaultGraphLoader());
     }
-    
-    public InfModel bind( Model model ) throws ReasonerException {
+
+    public InfModel bind(Model model) throws ReasonerException {
         log.fine("In bind!");
-    	return ModelFactory.createInfModel( bind( model.getGraph() ) );
-    }
-    
-    public PelletInfGraph bind( KnowledgeBase kb ) throws ReasonerException {
-        return new PelletInfGraph( kb, this, new DefaultGraphLoader() );
+        return ModelFactory.createInfModel(bind(model.getGraph()));
     }
 
-    public void setDerivationLogging( boolean enable ) {
+    public PelletInfGraph bind(KnowledgeBase kb) throws ReasonerException {
+        return new PelletInfGraph(kb, this, new DefaultGraphLoader());
     }
 
+    @Override
+    public void setDerivationLogging(boolean enable) {
+    }
+
+    @Override
     public void setParameter(Property arg0, Object arg1) {
     }
 
+    @Override
     public Model getReasonerCapabilities() {
         return reasonerCapabilities;
     }
-    
+
+    @Override
     public Capabilities getGraphCapabilities() {
         return graphCapabilities;
     }
 
+    @Override
     public void addDescription(Model arg0, Resource arg1) {
     }
 
+    @Override
     public boolean supportsProperty(Property property) {
         Model caps = getReasonerCapabilities();
-        if( caps == null ) return false;
+        if (caps == null) {
+            return false;
+        }
         return caps.contains(null, ReasonerVocabulary.supportsP, property);
     }
 

--- a/jena/src/main/java/org/mindswap/pellet/jena/PelletReasoner.java
+++ b/jena/src/main/java/org/mindswap/pellet/jena/PelletReasoner.java
@@ -90,8 +90,14 @@ public class PelletReasoner implements Reasoner {
         return fixedSchema;
     }
 
+    /**
+     * @deprecated
+     * @param fixedSchema 
+     */
     public void setFixedSchema(boolean fixedSchema) {
         this.fixedSchema = fixedSchema;
+        if(this.fixedSchema==false)
+            this.schema = null;
     }
 
     /**


### PR DESCRIPTION
Constructor adjusted so that schema is indicated as bound when argument is not null.
PelletInfGraph will now retrieve the schema when either bindSchema or bindFixedSchema is used.
Previously bindSchema would have no effect despite this being a Jena Reasoner interface method.
This change enables Pellet to work with Fuseki assembler ja:schema command.

Most of the changes on the page are due to the auto-formatting which I applied and didn't realise it had changed so much until after committing. The only real change is one line in the two arg constructor.

Other minor changes:
- Added override tags.
- Log set to final.
- Reformatted page for none aligned methods.
- Deprecated bindFixedSchema methods as now repetition of bindSchema and not part of Jena Reasoner interface.
- Added JavaDoc for bindSchema and bindFixedSchema methods to make clearer that the returned Reasoner needs to be used.
