### PR TITLE
Fixed NPE with Inf range and compile error

### DIFF
--- a/core/src/main/java/com/clarkparsia/pellet/datatypes/types/real/ContinuousRealInterval.java
+++ b/core/src/main/java/com/clarkparsia/pellet/datatypes/types/real/ContinuousRealInterval.java
@@ -303,10 +303,17 @@ public class ContinuousRealInterval {
 			if( other.lower != null )
 				return false;
 		}
+		else if( other.lower == null ) {
+			if( lower != null )
+				return false;
+		}
 		else if( OWLRealUtils.compare( lower, other.lower ) != 0 )
 			return false;
 		if( upper == null ) {
 			if( other.upper != null )
+				return false;
+		} else if( other.upper == null ) {
+			if( upper != null )
 				return false;
 		}
 		else if( OWLRealUtils.compare( upper, other.upper ) != 0 )

--- a/core/src/main/java/org/mindswap/pellet/utils/MultiValueMap.java
+++ b/core/src/main/java/org/mindswap/pellet/utils/MultiValueMap.java
@@ -67,7 +67,7 @@ public class MultiValueMap<K,V> extends HashMap<K,Set<V>> implements Map<K,Set<V
 		return values.addAll( collection );
 	}
     
-    public boolean remove( K key, V value ) {
+    public boolean removeSingle( K key, V value ) {
     	boolean removed = false;
     	
         Set<V> values = get( key );


### PR DESCRIPTION
1. Fixed compiler error in MultiValueMap remove method:

"Name clash: The method remove(K, V) of type MultiValueMap<K,V> has the same erasure as remove(Object, Object) of type HashMap<K,V> but does not override it"

2. Fixed NPE which occurs when lower/upper bound of other element is Infinity
```
java.lang.NullPointerException
	at com.clarkparsia.pellet.datatypes.OWLRealUtils.compare(OWLRealUtils.java:118)
	at com.clarkparsia.pellet.datatypes.types.real.ContinuousRealInterval.equals(ContinuousRealInterval.java:310)
	at java.util.AbstractList.equals(AbstractList.java:523)
	at com.clarkparsia.pellet.datatypes.types.datetime.RestrictedTimelineDatatype.intersect(RestrictedTimelineDatatype.java:571)
	at com.clarkparsia.pellet.datatypes.DatatypeReasonerImpl.normalizeVarRanges(DatatypeReasonerImpl.java:1138)
	at com.clarkparsia.pellet.datatypes.DatatypeReasonerImpl.isSatisfiable(DatatypeReasonerImpl.java:721)
	at com.clarkparsia.pellet.datatypes.DatatypeReasonerImpl.isSatisfiable(DatatypeReasonerImpl.java:665)
	at com.clarkparsia.pellet.datatypes.DatatypeReasonerImpl.isSatisfiable(DatatypeReasonerImpl.java:626)
	at org.mindswap.pellet.Literal.checkClash(Literal.java:369)
	at org.mindswap.pellet.Literal.addType(Literal.java:261)
	at org.mindswap.pellet.tableau.completion.CompletionStrategy.addType(CompletionStrategy.java:438)
	at org.mindswap.pellet.tableau.completion.rule.AllValuesRule.applyAllValues(AllValuesRule.java:175)
	at org.mindswap.pellet.tableau.completion.rule.SimpleAllValuesRule.applyAllValues(SimpleAllValuesRule.java:120)
	at org.mindswap.pellet.tableau.completion.CompletionStrategy.applyPropertyRestrictions(CompletionStrategy.java:603)
	at org.mindswap.pellet.tableau.completion.CompletionStrategy.addEdge(CompletionStrategy.java:583)
	at org.mindswap.pellet.tableau.completion.rule.SomeValuesRule.applySomeValuesRule(SomeValuesRule.java:186)
	at org.mindswap.pellet.tableau.completion.rule.SomeValuesRule.apply(SomeValuesRule.java:64)
	at org.mindswap.pellet.tableau.completion.rule.AbstractTableauRule.apply(AbstractTableauRule.java:64)
	at org.mindswap.pellet.tableau.completion.SROIQStrategy.complete(SROIQStrategy.java:157)
	at org.mindswap.pellet.ABox.isConsistent(ABox.java:1423)
	at org.mindswap.pellet.ABox.isType(ABox.java:852)
	at org.mindswap.pellet.KnowledgeBase.isType(KnowledgeBase.java:2997)
	at com.clarkparsia.pellet.owlapiv3.EntailmentChecker.visit(EntailmentChecker.java:403)
	at uk.ac.manchester.cs.owl.owlapi.OWLClassAssertionAxiomImpl.accept(OWLClassAssertionAxiomImpl.java:132)
	at com.clarkparsia.pellet.owlapiv3.EntailmentChecker.isEntailed(EntailmentChecker.java:120)
	at com.clarkparsia.pellet.owlapiv3.EntailmentChecker.isEntailed(EntailmentChecker.java:134)
	at com.clarkparsia.pellet.owlapiv3.PelletReasoner.isEntailed(PelletReasoner.java:872)
	at com.clarkparsia.pellet.owlapiv3.PelletReasoner.isEntailed(PelletReasoner.java:860)
	at org.dllearner.reasoning.OWLAPIReasoner.hasTypeImpl(OWLAPIReasoner.java:652)
	at org.dllearner.core.AbstractReasonerComponent.hasType(AbstractReasonerComponent.java:472)
	at org.dllearner.learningproblems.PosNegLPStandard.getPredAccuracyOrTooWeakExact(PosNegLPStandard.java:551)
	at org.dllearner.learningproblems.PosNegLPStandard.getAccuracyOrTooWeakExact(PosNegLPStandard.java:496)
	at org.dllearner.learningproblems.PosNegLPStandard.getAccuracyOrTooWeak(PosNegLPStandard.java:383)
	at org.dllearner.learningproblems.PosNegLPStandard.getAccuracyOrTooWeak(PosNegLPStandard.java:1)
	at org.dllearner.algorithms.celoe.CELOE.addNode(CELOE.java:588)
	at org.dllearner.algorithms.celoe.CELOE.start(CELOE.java:488)
	at org.dllearner.test.junit.LiteralLearningTest.genericNumericTypeTest(LiteralLearningTest.java:117)
	at org.dllearner.test.junit.LiteralLearningTest.dateTypeTest(LiteralLearningTest.java:150)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:44)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:41)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:76)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:193)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:52)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:191)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:42)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:184)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:236)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:675)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)

