### PR TITLE
Fix `PersistenceUpdatesTest`: correctly close and delete test file

### DIFF
--- a/owlapi/pom.xml
+++ b/owlapi/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>pellet-owlapi</artifactId>
-	<name>Pellet :: OWL API (ignazio1977 fork)</name>
+	<name>Pellet :: OWL API</name>
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Two commits:
1. Fix `PersistenceUpdatesTest` test case. It failed because there were try to delete test output file while it is not closed.
2. Rename project "Pellet :: OWL API (ignazio1977 fork)" back to "Pellet :: OWL API".